### PR TITLE
Disabled conflicting background colors

### DIFF
--- a/index.less
+++ b/index.less
@@ -143,13 +143,19 @@ atom-text-editor::shadow {
   background-color: #FFD0D0;
 }
 
-.text .source, .string.unquoted {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-.text .source .string.unquoted, .text .source .text .source {
-  background-color: rgba(0, 0, 0, 0.06);
-}
+// NOTE
+// Disabled these, because they don't play nice with the default line height
+// of 1.5, and don't really add significant usability improvements anyway.
+//
+// .text .source,
+// .string.unquoted {
+//   background-color: rgba(0, 0, 0, 0.05);
+// }
+//
+// .text .source .string.unquoted,
+// .text .source .text .source {
+//   background-color: rgba(0, 0, 0, 0.06);
+// }
 
 .meta.tag.preprocessor.xml {
   color: #68685B;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mac-classic",
   "theme": "syntax",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "private": true,
   "description": "A conversion of the original TextMate 'Mac Classic' theme",
   "repository": "https://github.com/chipersoft/atom-mac-classic",


### PR DESCRIPTION
Updated the css because the default line height of 1.5 conflicted with some background colors, resulting in weird lines.

I wouldn't mind taking over the repo btw, to keep it alive. I believe it is as easy as selecting me as the owner somewhere on the repo settings page.